### PR TITLE
improved the useLocalStorage hook to Handle Multiple Keys

### DIFF
--- a/videos/long/custom-react-hooks-useLocalStorage/index.tsx
+++ b/videos/long/custom-react-hooks-useLocalStorage/index.tsx
@@ -1,25 +1,25 @@
-import { useState } from 'react';
+import { useState } from "react";
 
-import { useLocalStorage } from './useLocalStorage';
+import { useLocalStorage } from "./useLocalStorage";
 
 const Demo = () => {
-  const [value, setValue] = useState('');
+  const [value, setValue] = useState("");
 
-  const { getItem, setItem, removeItem } = useLocalStorage('value');
+  const { getItem, setItem, removeItem } = useLocalStorage();
 
   return (
-    <div className='tutorial-shorts'>
-      <h1 className='mb-2 text-3xl font-bold'>useLocalStorage</h1>
+    <div className="tutorial-shorts">
+      <h1 className="mb-2 text-3xl font-bold">useLocalStorage</h1>
       <input
-        className='mb-4'
-        type='text'
+        className="mb-4"
+        type="text"
         value={value}
         onChange={(e) => setValue(e.target.value)}
       />
-      <div className='flex flex-row gap-4'>
-        <button onClick={() => setItem(value)}>Set</button>
-        <button onClick={() => console.log(getItem())}>Get</button>
-        <button onClick={removeItem}>Remove</button>
+      <div className="flex flex-row gap-4">
+        <button onClick={() => setItem("myKey", value)}>Set</button>
+        <button onClick={() => console.log(getItem("myKey"))}>Get</button>
+        <button onClick={() => removeItem("myKey")}>Remove</button>
       </div>
     </div>
   );

--- a/videos/long/custom-react-hooks-useLocalStorage/useLocalStorage.ts
+++ b/videos/long/custom-react-hooks-useLocalStorage/useLocalStorage.ts
@@ -1,5 +1,5 @@
-export const useLocalStorage = (key: string) => {
-  const setItem = (value: unknown) => {
+export const useLocalStorage = () => {
+  const setItem = (key: string, value: unknown) => {
     try {
       window.localStorage.setItem(key, JSON.stringify(value));
     } catch (error) {
@@ -7,7 +7,7 @@ export const useLocalStorage = (key: string) => {
     }
   };
 
-  const getItem = () => {
+  const getItem = (key: string) => {
     try {
       const item = window.localStorage.getItem(key);
       return item ? JSON.parse(item) : undefined;
@@ -16,7 +16,7 @@ export const useLocalStorage = (key: string) => {
     }
   };
 
-  const removeItem = () => {
+  const removeItem = (key: string) => {
     try {
       window.localStorage.removeItem(key);
     } catch (error) {


### PR DESCRIPTION
This pull request enhances the useLocalStorage hook to enable the management of multiple keys, addressing a common need mentioned in user comments on the video. 

What's Changed:
Modified the useLocalStorage hook to accept a dynamic `key` for local storage operations.
Updated the `setItem`, `getItem`, and `removeItem` functions to take a key argument.